### PR TITLE
Task Generate template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/lib/pq v1.8.0 // indirect
 	github.com/markbates/grift v1.5.0
 	github.com/markbates/refresh v1.11.1
+	github.com/pkg/errors v0.9.1
 	github.com/rogpeppe/go-internal v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,7 @@ github.com/gobuffalo/pop v4.13.1+incompatible/go.mod h1:DwBz3SD5SsHpTZiTubcsFWcV
 github.com/gobuffalo/pop/v5 v5.1.3 h1:XwXm2sJScNqc6dJOaMTAILECw6nqsf3cooNdleEcoWw=
 github.com/gobuffalo/pop/v5 v5.1.3/go.mod h1:fzUpBhQE48+kPczDbuJIuOCSS7OMqChoaGR6wj2j7Nc=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
+github.com/gobuffalo/tags v2.1.0+incompatible h1:qQjj3n2RtHxfooqXQ4/A9SsEfZ7/7guv8cp/GdAPa+Y=
 github.com/gobuffalo/tags v2.1.0+incompatible/go.mod h1:9XmhOkyaB7UzvuY4UoZO4s67q8/xRMVJEaakauVQYeY=
 github.com/gobuffalo/tags/v3 v3.0.2/go.mod h1:ZQeN6TCTiwAFnS0dNcbDtSgZDwNKSpqajvVtt6mlYpA=
 github.com/gobuffalo/tags/v3 v3.1.0 h1:mzdCYooN2VsLRr8KIAdEZ1lh1Py7JSMsiEGCGata2AQ=

--- a/plugins.go
+++ b/plugins.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wawandco/oxplugins/tools/ox"
 	"github.com/wawandco/oxplugins/tools/refresh"
 	"github.com/wawandco/oxplugins/tools/standard"
+	"github.com/wawandco/oxplugins/tools/template"
 	"github.com/wawandco/oxplugins/tools/webpack"
 	"github.com/wawandco/oxplugins/tools/yarn"
 )
@@ -46,6 +47,7 @@ var Base = []plugins.Plugin{
 
 	// Generators
 	&ox.Generator{},
+	&template.Generator{},
 
 	// Initializer
 	&refresh.Initializer{},

--- a/tools/template/generator.go
+++ b/tools/template/generator.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,8 +55,9 @@ func (g Generator) generateTemplate(root, filename string) error {
 // generateFilePath translates the required path to create the file properly
 func (g Generator) generateFilePath(dirPath, filename string) string {
 	base := strings.Split(filename, ".")[0]
+	file := base + ".plush.html"
 
-	return fmt.Sprintf("%s/%s.plush.html", dirPath, base)
+	return filepath.Join(dirPath, file)
 }
 
 func (g Generator) exists(path string) bool {

--- a/tools/template/generator.go
+++ b/tools/template/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -37,8 +38,7 @@ func (g Generator) generateTemplate(root, filename string) error {
 		return errors.Errorf("folder '%s' do not exists on your buffalo app, please ensure the folder exists in order to proceed", dirpath)
 	}
 
-	tmpl := fmt.Sprintf("%s/%s.plush.html", dirpath, filename)
-
+	tmpl := g.generateFilePath(dirpath, filename)
 	if g.exists(tmpl) {
 		return errors.Errorf("template already exists")
 	}
@@ -51,6 +51,13 @@ func (g Generator) generateTemplate(root, filename string) error {
 	defer file.Close()
 
 	return nil
+}
+
+// generateFilePath translates the required path to create the file properly
+func (g Generator) generateFilePath(dirPath, filename string) string {
+	base := strings.Split(filename, ".")[0]
+
+	return fmt.Sprintf("%s/%s.plush.html", dirPath, base)
 }
 
 func (g Generator) exists(path string) bool {

--- a/tools/template/generator.go
+++ b/tools/template/generator.go
@@ -1,0 +1,60 @@
+package template
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+// Generator allows to identify template as a plugin
+type Generator struct{}
+
+// Name returns the name of the generator plugin
+func (g Generator) Name() string {
+	return "template"
+}
+
+// Generate generates an empty [name].plush.html file
+func (g Generator) Generate(ctx context.Context, root string, args []string) error {
+	if len(args) < 3 {
+		return errors.Errorf("no name specified, please use `ox generate template [name]`")
+	}
+
+	if err := g.generateTemplate(root, args[2]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g Generator) generateTemplate(root, filename string) error {
+	dirpath := filepath.Join(root, "app", "templates")
+
+	if !g.exists(dirpath) {
+		return errors.Errorf("folder '%s' do not exists on your buffalo app, please ensure the folder exists in order to proceed", dirpath)
+	}
+
+	tmpl := fmt.Sprintf("%s/%s.plush.html", dirpath, filename)
+
+	if g.exists(tmpl) {
+		return errors.Errorf("template already exists")
+	}
+
+	file, err := os.Create(tmpl)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	return nil
+}
+
+func (g Generator) exists(path string) bool {
+	_, err := os.Stat(path)
+
+	return !os.IsNotExist(err)
+}

--- a/tools/template/generator_test.go
+++ b/tools/template/generator_test.go
@@ -1,0 +1,79 @@
+package template
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_GenerateTemplate(t *testing.T) {
+	g := Generator{}
+
+	t.Run("generate template", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, "app", "templates"), os.ModePerm); err != nil {
+			t.Errorf("creating templates folder should not be error, but got %v", err)
+		}
+
+		if err := g.generateTemplate(dir, "amazon"); err != nil {
+			t.Errorf("should not be error, but got %v", err)
+		}
+	})
+
+	t.Run("generated template already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		templatesPath := filepath.Join(dir, "app", "templates")
+		if err := os.MkdirAll(templatesPath, os.ModePerm); err != nil {
+			t.Errorf("creating templates folder should not be error, but got %v", err)
+		}
+
+		if _, err := os.Create(filepath.Join(templatesPath, "ebay.plush.html")); err != nil {
+			t.Errorf("should not be error, but got %v", err)
+		}
+
+		if err := g.generateTemplate(dir, "ebay"); err == nil {
+			t.Errorf("should error, but got %v", err)
+		}
+	})
+
+	t.Run("generate template when templates folder do not exists", func(t *testing.T) {
+		if err := g.generateTemplate("", "user"); err == nil {
+			t.Errorf("should error, but got %v", err)
+		}
+	})
+}
+
+func Test_GenerateFilePath(t *testing.T) {
+	g := Generator{}
+	cases := []struct {
+		expected string
+		fileName string
+		testName string
+	}{
+		{
+			testName: "normal filename",
+			fileName: "user",
+			expected: "user.plush.html",
+		},
+		{
+			testName: "filename with extension 1",
+			fileName: "amazon.plush.html",
+			expected: "amazon.plush.html",
+		},
+		{
+			testName: "filename with extension 2",
+			fileName: "ebay.html",
+			expected: "ebay.plush.html",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.testName, func(t *testing.T) {
+			filePath := g.generateFilePath("", c.fileName)
+
+			if filePath != c.expected {
+				t.Errorf("test was expecting %s, got %s", c.expected, filePath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new generator for oxpecker, the templates generator should work by writing the command:
```
ox generate template user
```
and should generate an empty "user.plush.html" file. I added some sort of restrictions for the name args, on case someone writer user.plush.html, the generator will still generate "user.plush.html" instead of "user.plush.html.plush.html"