### PR TITLE
Setting GO_ENV to be "development" if not set when `dev` invoked

### DIFF
--- a/lifecycle/dev/command.go
+++ b/lifecycle/dev/command.go
@@ -10,9 +10,12 @@ import (
 
 var _ plugins.Command = (*Command)(nil)
 
-// dev is the dev command.
+// Command is the dev command, it runs the dev plugins, each one on a different
+// go routine. the detail to what happen on each of these plugins is up to
+// each of the Developer plugins.
 type Command struct {
 	developers []Developer
+	beforeDevs []BeforeDeveloper
 }
 
 func (d Command) Name() string {
@@ -28,9 +31,16 @@ func (d Command) HelpText() string {
 	return "calls NPM or yarn to start webpack watching the assetst"
 }
 
-// Run calls NPM or yarn to start webpack watching the assets
-// Also starts refresh listening for the changes in Go files.
+// Run calls each of the beforedeveloper plugins and then
+// executes Developer plugins in parallel.
 func (d *Command) Run(ctx context.Context, root string, args []string) error {
+	for _, bd := range d.beforeDevs {
+		err := bd.BeforeDevelop(ctx, root)
+		if err != nil {
+			return err
+		}
+	}
+
 	var wg sync.WaitGroup
 	for _, tool := range d.developers {
 		// Each of the tools runs in parallel
@@ -49,13 +59,16 @@ func (d *Command) Run(ctx context.Context, root string, args []string) error {
 	return nil
 }
 
+// Receive Developer and BeforeDeveloper plugins and store these
+// in the Command to be used when the command is invoked.
 func (d *Command) Receive(plugins []plugins.Plugin) {
 	for _, tool := range plugins {
-		ptool, ok := tool.(Developer)
-		if !ok {
-			continue
+		if ptool, ok := tool.(Developer); ok {
+			d.developers = append(d.developers, ptool)
 		}
 
-		d.developers = append(d.developers, ptool)
+		if bdev, ok := tool.(BeforeDeveloper); ok {
+			d.beforeDevs = append(d.beforeDevs, bdev)
+		}
 	}
 }

--- a/lifecycle/dev/command_test.go
+++ b/lifecycle/dev/command_test.go
@@ -1,0 +1,78 @@
+package dev_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/wawandco/oxplugins/lifecycle/dev"
+	"github.com/wawandco/oxplugins/plugins"
+)
+
+type (
+	plugin struct {
+		ranAt time.Time
+		ran   bool
+	}
+
+	developer struct {
+		plugin
+	}
+
+	beforeDeveloper struct {
+		plugin
+	}
+)
+
+func (pl plugin) Name() string {
+	return "aaa"
+}
+
+func (d *developer) Develop(context.Context, string) error {
+	d.ran = true
+	d.ranAt = time.Now()
+	return nil
+}
+
+func (d *beforeDeveloper) BeforeDevelop(context.Context, string) error {
+	d.ranAt = time.Now()
+	d.ran = true
+	time.Sleep(10 * time.Millisecond)
+
+	return nil
+}
+
+func TestCommand(t *testing.T) {
+
+	plb := plugin{}
+
+	pls := []plugins.Plugin{
+		&plb,
+		&developer{},
+		&beforeDeveloper{},
+	}
+
+	c := dev.Command{}
+	c.Receive(pls)
+
+	err := c.Run(context.Background(), "", []string{})
+	if err != nil {
+		t.Errorf("error should be nil, got %v", err)
+	}
+
+	if plb.ran == true {
+		t.Errorf("plugin should not have ran in true")
+	}
+
+	if pls[1].(*developer).ran == false {
+		t.Errorf("developer plugin should run")
+	}
+
+	if pls[2].(*beforeDeveloper).ran == false {
+		t.Errorf("beforeDeveloper plugin should run")
+	}
+
+	if pls[2].(*beforeDeveloper).ranAt.After(pls[1].(*developer).ranAt) {
+		t.Errorf("beforeDeveloper plugin should run before developer plugin")
+	}
+}

--- a/lifecycle/dev/command_test.go
+++ b/lifecycle/dev/command_test.go
@@ -11,16 +11,19 @@ import (
 
 type (
 	plugin struct {
-		ranAt time.Time
-		ran   bool
+		ran bool
 	}
 
 	developer struct {
 		plugin
+
+		ranAt time.Time
 	}
 
 	beforeDeveloper struct {
 		plugin
+
+		ranAt time.Time
 	}
 )
 

--- a/lifecycle/dev/developer.go
+++ b/lifecycle/dev/developer.go
@@ -2,9 +2,18 @@ package dev
 
 import "context"
 
-// Developer is a tool that will be invoked for development
-// purposes. Things like webpack with --watch and refresh.
-type Developer interface {
-	Name() string
-	Develop(context.Context, string) error
-}
+type (
+	// Developer is a tool that will be invoked for development
+	// purposes. Things like webpack with --watch and refresh.
+	Developer interface {
+		Name() string
+		Develop(context.Context, string) error
+	}
+
+	// BeforeDeveloper is an interface that will allow to identify those plugins that
+	// need to run before the dev commands is run.
+	BeforeDeveloper interface {
+		Name() string
+		BeforeDevelop(context.Context, string) error
+	}
+)

--- a/plugins.go
+++ b/plugins.go
@@ -34,6 +34,7 @@ var Base = []plugins.Plugin{
 	&webpack.Plugin{},
 	&refresh.Plugin{},
 	&yarn.Plugin{},
+	&envy.Developer{},
 
 	// Developer Lifecycle plugins
 	&build.Command{},

--- a/tools/envy/developer.go
+++ b/tools/envy/developer.go
@@ -1,0 +1,28 @@
+package envy
+
+import (
+	"context"
+	"os"
+
+	"github.com/gobuffalo/envy"
+)
+
+// Developer plugin sets the GO_ENV variable
+// before app starts if not set.
+type Developer struct{}
+
+func (t Developer) Name() string {
+	return "envy/developer"
+}
+
+func (b *Developer) BeforeDevelop(ctx context.Context, root string, args []string) error {
+	if env := os.Getenv("GO_ENV"); env != "" {
+		envy.Set("GO_ENV", env)
+
+		return nil
+	}
+
+	os.Setenv("GO_ENV", "development")
+	envy.Set("GO_ENV", "development")
+	return nil
+}

--- a/tools/envy/developer_test.go
+++ b/tools/envy/developer_test.go
@@ -1,0 +1,49 @@
+package envy_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/gobuffalo/envy"
+	envypl "github.com/wawandco/oxplugins/tools/envy"
+)
+
+func TestDeveloper(t *testing.T) {
+	t.Run("GO_ENV Not set", func(t *testing.T) {
+		d := envypl.Developer{}
+		err := d.BeforeDevelop(context.Background(), "", []string{})
+		if err != nil {
+			t.Errorf("err should be nil, got %v", err)
+		}
+
+		env := os.Getenv("GO_ENV")
+		if env != "development" {
+			t.Errorf("GO_ENV should be 'development', got %v", env)
+		}
+
+		env = envy.Get("GO_ENV", "")
+		if env != "development" {
+			t.Errorf("GO_ENV should be 'development', got %v", env)
+		}
+	})
+
+	t.Run("GO_ENV Set previously", func(t *testing.T) {
+		os.Setenv("GO_ENV", "somethingelse")
+		d := envypl.Developer{}
+		err := d.BeforeDevelop(context.Background(), "", []string{})
+		if err != nil {
+			t.Errorf("err should be nil, got %v", err)
+		}
+
+		env := os.Getenv("GO_ENV")
+		if env != "somethingelse" {
+			t.Errorf("GO_ENV should be 'somethingelse', got %v", env)
+		}
+
+		env = envy.Get("GO_ENV", "")
+		if env != "somethingelse" {
+			t.Errorf("GO_ENV should be 'somethingelse', got %v", env)
+		}
+	})
+}


### PR DESCRIPTION
This PR adds a BeforeDeveloper to envy that sets the GO_ENV to be `development` if not set, otherwise it will ensure that envy has the same value that GO_ENV has.