### PR TITLE
Task liquibase migrations

### DIFF
--- a/tools/liquibase/generator_test.go
+++ b/tools/liquibase/generator_test.go
@@ -3,141 +3,240 @@ package liquibase
 import (
 	"context"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
-	"regexp"
+	"strings"
 	"testing"
 )
 
-func TestLiquibaseGenerator(t *testing.T) {
-	t.Run("FileDoesNotExist", func(t *testing.T) {
-		root := t.TempDir()
-		err := os.Chdir(root)
-		if err != nil {
-			t.Error("could not change to temp directory")
-		}
+// func TestLiquibaseGenerator(t *testing.T) {
+// 	t.Run("FileDoesNotExist", func(t *testing.T) {
+// 		root := t.TempDir()
+// 		err := os.Chdir(root)
+// 		if err != nil {
+// 			t.Error("could not change to temp directory")
+// 		}
 
-		args := []string{"generate", "migration", "addDevices"}
+// 		args := []string{"generate", "migration", "addDevices"}
 
-		g := Generator{
-			testPrefix: "testfile001",
-		}
+// 		g := Generator{
+// 			testPrefix: "testfile001",
+// 		}
 
-		err = g.Generate(context.Background(), root, args)
-		if err != nil {
-			t.Fatalf("Error should be nil, got %v", err)
-		}
-		path := filepath.Join(root, "migrations", "testfile001-add_devices.xml")
-		_, err = os.Stat(path)
-		if err != nil {
-			t.Fatalf("Error should be nil, got %v", err)
-		}
-		content, err := ioutil.ReadFile(path)
-		if err != nil {
-			log.Fatal(err)
-		}
-		text := string(content)
-		matched, err := regexp.MatchString(`<changeSet id="testfile001-add_devices" author="ox">`, text)
+// 		err = g.Generate(context.Background(), root, args)
+// 		if err != nil {
+// 			t.Fatalf("Error should be nil, got %v", err)
+// 		}
+// 		path := filepath.Join(root, "migrations", "testfile001-add_devices.xml")
+// 		_, err = os.Stat(path)
+// 		if err != nil {
+// 			t.Fatalf("Error should be nil, got %v", err)
+// 		}
+// 		content, err := ioutil.ReadFile(path)
+// 		if err != nil {
+// 			log.Fatal(err)
+// 		}
+// 		text := string(content)
+// 		matched, err := regexp.MatchString(`<changeSet id="testfile001-add_devices" author="ox">`, text)
 
-		if !matched {
-			t.Fatalf("File's content is not correct, %v", err)
-		}
+// 		if !matched {
+// 			t.Fatalf("File's content is not correct, %v", err)
+// 		}
 
-	})
-	t.Run("FileDoesNotExist/name", func(t *testing.T) {
-		root := t.TempDir()
-		err := os.Chdir(root)
-		if err != nil {
-			t.Error("could not change to temp directory")
-		}
+// 	})
+// 	t.Run("FileDoesNotExist/name", func(t *testing.T) {
+// 		root := t.TempDir()
+// 		err := os.Chdir(root)
+// 		if err != nil {
+// 			t.Error("could not change to temp directory")
+// 		}
 
-		args := []string{"generate", "migration", "location/addDevices"}
+// 		args := []string{"generate", "migration", "location/addDevices"}
 
-		g := Generator{
-			testPrefix: "testfile001",
-		}
+// 		g := Generator{
+// 			testPrefix: "testfile001",
+// 		}
 
-		err = g.Generate(context.Background(), root, args)
+// 		err = g.Generate(context.Background(), root, args)
 
-		if err != nil {
-			t.Fatalf("Error should be nil, got %v", err)
-		}
-		path := filepath.Join(root, "migrations", "location", "testfile001-add_devices.xml")
-		_, err = os.Stat(path)
-		if err != nil {
-			t.Fatalf("Error should be nil, got %v", err)
-		}
+// 		if err != nil {
+// 			t.Fatalf("Error should be nil, got %v", err)
+// 		}
+// 		path := filepath.Join(root, "migrations", "location", "testfile001-add_devices.xml")
+// 		_, err = os.Stat(path)
+// 		if err != nil {
+// 			t.Fatalf("Error should be nil, got %v", err)
+// 		}
 
-		content, err := ioutil.ReadFile(path)
-		if err != nil {
-			log.Fatal(err)
-		}
-		text := string(content)
-		matched, err := regexp.MatchString(`<changeSet id="testfile001-add_devices" author="ox">`, text)
+// 		content, err := ioutil.ReadFile(path)
+// 		if err != nil {
+// 			log.Fatal(err)
+// 		}
+// 		text := string(content)
+// 		matched, err := regexp.MatchString(`<changeSet id="testfile001-add_devices" author="ox">`, text)
 
-		if !matched {
-			t.Fatalf("File's content is not correct, %v", err)
-		}
+// 		if !matched {
+// 			t.Fatalf("File's content is not correct, %v", err)
+// 		}
 
-	})
+// 	})
 
-	t.Run("FileDoesNotExist/.", func(t *testing.T) {
-		root := t.TempDir()
-		err := os.Chdir(root)
-		if err != nil {
-			t.Error("could not change to temp directory")
-		}
+// 	t.Run("FileDoesNotExist/.", func(t *testing.T) {
+// 		root := t.TempDir()
+// 		err := os.Chdir(root)
+// 		if err != nil {
+// 			t.Error("could not change to temp directory")
+// 		}
 
-		args := []string{"generate", "migration", "."}
+// 		args := []string{"generate", "migration", "."}
 
+// 		g := Generator{}
+
+// 		err = g.Generate(context.Background(), root, args)
+
+// 		if err != ErrName {
+// 			t.Fatalf("Error should be type ErrName, got %v", err)
+// 		}
+
+// 	})
+
+// 	t.Run("genpathTest", func(t *testing.T) {
+
+// 		root := t.TempDir()
+// 		err := os.Chdir(root)
+// 		if err != nil {
+// 			t.Error("could not change to temp directory")
+// 		}
+
+// 		args := []string{"generate", "migration", "addDevices"}
+
+// 		g := Generator{
+// 			testPrefix: "testfile001",
+// 		}
+// 		ret, err := g.genPath(args, root)
+// 		if err != nil {
+// 			t.Fatalf("error should bw nil got, %v", err)
+// 		}
+// 		path := filepath.Join(root, "migrations", "testfile001-add_devices.xml")
+
+// 		expected := []string{path, "add_devices", "testfile001"}
+
+// 		match := g.equal(ret, expected)
+
+// 		if !match {
+// 			t.Fatalf("did not generate the correct path")
+// 		}
+
+// 	})
+
+// }
+
+func TestGeneratorRun(t *testing.T) {
+	t.Run("incomplete arguments", func(t *testing.T) {
 		g := Generator{}
-
-		err = g.Generate(context.Background(), root, args)
-
-		if err != ErrName {
-			t.Fatalf("Error should be type ErrName, got %v", err)
+		err := g.Generate(context.Background(), "", []string{"a", "b"})
+		if err != ErrNameArgMissing {
+			t.Errorf("err should be %v, got %v", ErrNameArgMissing, err)
 		}
-
 	})
 
-	t.Run("genpathTest", func(t *testing.T) {
-
+	t.Run("simple", func(t *testing.T) {
 		root := t.TempDir()
 		err := os.Chdir(root)
 		if err != nil {
 			t.Error("could not change to temp directory")
 		}
 
-		args := []string{"generate", "migration", "addDevices"}
-
-		g := Generator{
-			testPrefix: "testfile001",
-		}
-		ret, err := g.genPath(args, root)
+		g := Generator{mockTimestamp: "12345"}
+		err = g.Generate(context.Background(), root, []string{"generate", "migration", "aaa"})
 		if err != nil {
-			t.Fatalf("error should bw nil got, %v", err)
-		}
-		path := filepath.Join(root, "migrations", "testfile001-add_devices.xml")
-
-		expected := []string{path, "add_devices", "testfile001"}
-
-		match := g.equal(ret, expected)
-
-		if !match {
-			t.Fatalf("did not generate the correct path")
+			t.Errorf("error should be nil, got %v", err)
 		}
 
+		path := filepath.Join(root, "12345-aaa.xml")
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created the file in the root")
+		}
+
+		d, err := ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, "12345-aaa") {
+			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
 	})
 
+	t.Run("folder", func(t *testing.T) {
+		root := t.TempDir()
+		err := os.Chdir(root)
+		if err != nil {
+			t.Error("could not change to temp directory")
+		}
+
+		g := Generator{mockTimestamp: "12345"}
+		err = g.Generate(context.Background(), root, []string{"generate", "migration", "folder/is/here/aaa"})
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		path := filepath.Join(root, filepath.Join("folder", "is", "here", "12345-aaa.xml"))
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created the file in the root")
+		}
+
+		d, err := ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, "12345-aaa") {
+			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
+	})
+
+	t.Run("folder exists", func(t *testing.T) {
+		root := t.TempDir()
+		err := os.Chdir(root)
+		if err != nil {
+			t.Error("could not change to temp directory")
+		}
+
+		err = os.MkdirAll(filepath.Join("folder", "is", "here"), 0755)
+		if err != nil {
+			t.Fatal("could not create the folder")
+		}
+
+		g := Generator{mockTimestamp: "12345"}
+		err = g.Generate(context.Background(), root, []string{"generate", "migration", "folder/is/here/aaa"})
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		path := filepath.Join(root, filepath.Join("folder", "is", "here", "12345-aaa.xml"))
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created the file in the root")
+		}
+
+		d, err := ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, "12345-aaa") {
+			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
+	})
 }
 
-func TestComposeName(t *testing.T) {
-	g := Generator{
-		testPrefix: "composename",
-	}
+func TestGeneratorComposeName(t *testing.T) {
+	g := Generator{}
 
-	filename, err := g.composeName("addDevices")
+	filename, err := g.composeFilename("addDevices", "composename")
 	if err != nil {
 		t.Errorf("err should be nil, got %v", err)
 	}
@@ -149,18 +248,14 @@ func TestComposeName(t *testing.T) {
 }
 
 func TestComposeNameInvalid(t *testing.T) {
-	g := Generator{
-		testPrefix: "composename",
-	}
-
-	_, err := g.composeName(".")
+	g := Generator{}
+	_, err := g.composeFilename(".", "composename")
 	if err != ErrInvalidName {
 		t.Errorf("err should be ErrInvalidName, got %v", err)
 	}
 
-	_, err = g.composeName("/")
+	_, err = g.composeFilename("/", "composename")
 	if err != ErrInvalidName {
 		t.Errorf("err should be ErrInvalidName, got %v", err)
 	}
-
 }

--- a/tools/liquibase/generator_test.go
+++ b/tools/liquibase/generator_test.go
@@ -131,3 +131,36 @@ func TestLiquibaseGenerator(t *testing.T) {
 	})
 
 }
+
+func TestComposeName(t *testing.T) {
+	g := Generator{
+		testPrefix: "composename",
+	}
+
+	filename, err := g.composeName("addDevices")
+	if err != nil {
+		t.Errorf("err should be nil, got %v", err)
+	}
+
+	expected := "composename-add_devices.xml"
+	if filename != expected {
+		t.Errorf("filename should be %v, got %v", expected, filename)
+	}
+}
+
+func TestComposeNameInvalid(t *testing.T) {
+	g := Generator{
+		testPrefix: "composename",
+	}
+
+	_, err := g.composeName(".")
+	if err != ErrInvalidName {
+		t.Errorf("err should be ErrInvalidName, got %v", err)
+	}
+
+	_, err = g.composeName("/")
+	if err != ErrInvalidName {
+		t.Errorf("err should be ErrInvalidName, got %v", err)
+	}
+
+}

--- a/tools/liquibase/generator_test.go
+++ b/tools/liquibase/generator_test.go
@@ -9,128 +9,6 @@ import (
 	"testing"
 )
 
-// func TestLiquibaseGenerator(t *testing.T) {
-// 	t.Run("FileDoesNotExist", func(t *testing.T) {
-// 		root := t.TempDir()
-// 		err := os.Chdir(root)
-// 		if err != nil {
-// 			t.Error("could not change to temp directory")
-// 		}
-
-// 		args := []string{"generate", "migration", "addDevices"}
-
-// 		g := Generator{
-// 			testPrefix: "testfile001",
-// 		}
-
-// 		err = g.Generate(context.Background(), root, args)
-// 		if err != nil {
-// 			t.Fatalf("Error should be nil, got %v", err)
-// 		}
-// 		path := filepath.Join(root, "migrations", "testfile001-add_devices.xml")
-// 		_, err = os.Stat(path)
-// 		if err != nil {
-// 			t.Fatalf("Error should be nil, got %v", err)
-// 		}
-// 		content, err := ioutil.ReadFile(path)
-// 		if err != nil {
-// 			log.Fatal(err)
-// 		}
-// 		text := string(content)
-// 		matched, err := regexp.MatchString(`<changeSet id="testfile001-add_devices" author="ox">`, text)
-
-// 		if !matched {
-// 			t.Fatalf("File's content is not correct, %v", err)
-// 		}
-
-// 	})
-// 	t.Run("FileDoesNotExist/name", func(t *testing.T) {
-// 		root := t.TempDir()
-// 		err := os.Chdir(root)
-// 		if err != nil {
-// 			t.Error("could not change to temp directory")
-// 		}
-
-// 		args := []string{"generate", "migration", "location/addDevices"}
-
-// 		g := Generator{
-// 			testPrefix: "testfile001",
-// 		}
-
-// 		err = g.Generate(context.Background(), root, args)
-
-// 		if err != nil {
-// 			t.Fatalf("Error should be nil, got %v", err)
-// 		}
-// 		path := filepath.Join(root, "migrations", "location", "testfile001-add_devices.xml")
-// 		_, err = os.Stat(path)
-// 		if err != nil {
-// 			t.Fatalf("Error should be nil, got %v", err)
-// 		}
-
-// 		content, err := ioutil.ReadFile(path)
-// 		if err != nil {
-// 			log.Fatal(err)
-// 		}
-// 		text := string(content)
-// 		matched, err := regexp.MatchString(`<changeSet id="testfile001-add_devices" author="ox">`, text)
-
-// 		if !matched {
-// 			t.Fatalf("File's content is not correct, %v", err)
-// 		}
-
-// 	})
-
-// 	t.Run("FileDoesNotExist/.", func(t *testing.T) {
-// 		root := t.TempDir()
-// 		err := os.Chdir(root)
-// 		if err != nil {
-// 			t.Error("could not change to temp directory")
-// 		}
-
-// 		args := []string{"generate", "migration", "."}
-
-// 		g := Generator{}
-
-// 		err = g.Generate(context.Background(), root, args)
-
-// 		if err != ErrName {
-// 			t.Fatalf("Error should be type ErrName, got %v", err)
-// 		}
-
-// 	})
-
-// 	t.Run("genpathTest", func(t *testing.T) {
-
-// 		root := t.TempDir()
-// 		err := os.Chdir(root)
-// 		if err != nil {
-// 			t.Error("could not change to temp directory")
-// 		}
-
-// 		args := []string{"generate", "migration", "addDevices"}
-
-// 		g := Generator{
-// 			testPrefix: "testfile001",
-// 		}
-// 		ret, err := g.genPath(args, root)
-// 		if err != nil {
-// 			t.Fatalf("error should bw nil got, %v", err)
-// 		}
-// 		path := filepath.Join(root, "migrations", "testfile001-add_devices.xml")
-
-// 		expected := []string{path, "add_devices", "testfile001"}
-
-// 		match := g.equal(ret, expected)
-
-// 		if !match {
-// 			t.Fatalf("did not generate the correct path")
-// 		}
-
-// 	})
-
-// }
-
 func TestGeneratorRun(t *testing.T) {
 	t.Run("incomplete arguments", func(t *testing.T) {
 		g := Generator{}
@@ -182,7 +60,7 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
-		path := filepath.Join(root, filepath.Join("folder", "is", "here", "12345-aaa.xml"))
+		path := filepath.Join(root, "folder", "is", "here", "12345-aaa.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
 			t.Error("should have created the file in the root")
@@ -216,7 +94,7 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("error should be nil, got %v", err)
 		}
 
-		path := filepath.Join(root, filepath.Join("folder", "is", "here", "12345-aaa.xml"))
+		path := filepath.Join(root, "folder", "is", "here", "12345-aaa.xml")
 		_, err = os.Stat(path)
 		if os.IsNotExist(err) {
 			t.Error("should have created the file in the root")
@@ -231,31 +109,71 @@ func TestGeneratorRun(t *testing.T) {
 			t.Errorf("file content %v should contain %v", content, "12345-aaa")
 		}
 	})
+
+	t.Run("different base", func(t *testing.T) {
+		root := t.TempDir()
+		err := os.Chdir(root)
+		if err != nil {
+			t.Error("could not change to temp directory")
+		}
+
+		err = os.MkdirAll(filepath.Join("folder", "is", "here"), 0755)
+		if err != nil {
+			t.Fatal("could not create the folder")
+		}
+
+		g := Generator{
+			mockTimestamp: "12345",
+			baseFolder:    "migrations",
+		}
+
+		err = g.Generate(context.Background(), root, []string{"generate", "migration", "aaa"})
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		path := filepath.Join(root, "migrations", "12345-aaa.xml")
+		_, err = os.Stat(path)
+		if os.IsNotExist(err) {
+			t.Error("should have created the file in the root/migrations folder")
+		}
+
+		d, err := ioutil.ReadFile(path)
+		if err != nil {
+			t.Errorf("error should be nil, got %v", err)
+		}
+
+		if content := string(d); !strings.Contains(content, "12345-aaa") {
+			t.Errorf("file content %v should contain %v", content, "12345-aaa")
+		}
+	})
 }
 
 func TestGeneratorComposeName(t *testing.T) {
-	g := Generator{}
+	t.Run("Valid name", func(t *testing.T) {
+		g := Generator{}
 
-	filename, err := g.composeFilename("addDevices", "composename")
-	if err != nil {
-		t.Errorf("err should be nil, got %v", err)
-	}
+		filename, err := g.composeFilename("addDevices", "composename")
+		if err != nil {
+			t.Errorf("err should be nil, got %v", err)
+		}
 
-	expected := "composename-add_devices.xml"
-	if filename != expected {
-		t.Errorf("filename should be %v, got %v", expected, filename)
-	}
-}
+		expected := "composename-add_devices.xml"
+		if filename != expected {
+			t.Errorf("filename should be %v, got %v", expected, filename)
+		}
+	})
 
-func TestComposeNameInvalid(t *testing.T) {
-	g := Generator{}
-	_, err := g.composeFilename(".", "composename")
-	if err != ErrInvalidName {
-		t.Errorf("err should be ErrInvalidName, got %v", err)
-	}
+	t.Run("Invalid name", func(t *testing.T) {
+		g := Generator{}
+		_, err := g.composeFilename(".", "composename")
+		if err != ErrInvalidName {
+			t.Errorf("err should be ErrInvalidName, got %v", err)
+		}
 
-	_, err = g.composeFilename("/", "composename")
-	if err != ErrInvalidName {
-		t.Errorf("err should be ErrInvalidName, got %v", err)
-	}
+		_, err = g.composeFilename("/", "composename")
+		if err != ErrInvalidName {
+			t.Errorf("err should be ErrInvalidName, got %v", err)
+		}
+	})
 }

--- a/tools/liquibase/template.go
+++ b/tools/liquibase/template.go
@@ -1,13 +1,8 @@
 package liquibase
 
-type data struct {
-	Filename  string
-	Timestamp string
-}
-
 var migrationTemplate = `
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
-	<changeSet id="{{.Time}}-{{.Name}}" author="ox">
+	<changeSet id="{{.}}" author="ox">
 		<sql></sql>
 		<rollback></rollback>
 	</changeSet>

--- a/tools/liquibase/template.go
+++ b/tools/liquibase/template.go
@@ -1,9 +1,14 @@
 package liquibase
 
-var mainTemplate = `<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
-<changeSet id="{{.Time}}-{{.Name}}" author="ox">
-	<sql>
-	</sql>
-	<rollback></rollback>
-</changeSet>
+type data struct {
+	Filename  string
+	Timestamp string
+}
+
+var migrationTemplate = `
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+	<changeSet id="{{.Time}}-{{.Name}}" author="ox">
+		<sql></sql>
+		<rollback></rollback>
+	</changeSet>
 </databaseChangeLog>`


### PR DESCRIPTION
This PR changes the way our Liquidase migrations work. here are some example of how it will work (in the plugin and tests covered).

```
- "ox generate migration name" generates [timestamp]-name.xml
- "ox generate migration folder/name" generates folder/[timestamp]-name.xml
- "ox generate migration name --base migrations" generates migrations/[timestamp]-name.xml
```