### PR TITLE
Task generate resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,6 @@ require (
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 	golang.org/x/mod v0.4.0
 	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
-	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 // indirect
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )

--- a/plugins.go
+++ b/plugins.go
@@ -9,6 +9,7 @@ import (
 	"github.com/wawandco/oxplugins/lifecycle/test"
 	"github.com/wawandco/oxplugins/plugins"
 	"github.com/wawandco/oxplugins/tools/buffalo/model"
+	"github.com/wawandco/oxplugins/tools/buffalo/resource"
 	"github.com/wawandco/oxplugins/tools/buffalo/template"
 	"github.com/wawandco/oxplugins/tools/cli/help"
 	"github.com/wawandco/oxplugins/tools/docker"
@@ -56,6 +57,7 @@ var Base = []plugins.Plugin{
 	&ox.Generator{},
 	&template.Generator{},
 	&model.Generator{},
+	&resource.Generator{},
 
 	// Initializer
 	&refresh.Initializer{},

--- a/tools/buffalo/model/attributes.go
+++ b/tools/buffalo/model/attributes.go
@@ -7,13 +7,13 @@ import (
 )
 
 type attr struct {
-	Name   name.Ident
-	goType string
+	Name       name.Ident
+	CommonType string
 }
 
 // GoType returns the Go type for an Attr based on its type
 func (a attr) GoType() string {
-	switch strings.ToLower(a.goType) {
+	switch strings.ToLower(a.CommonType) {
 	case "text":
 		return "string"
 	case "timestamp", "datetime", "date", "time":
@@ -45,7 +45,7 @@ func (a attr) GoType() string {
 	case "[]byte", "blob":
 		return "[]byte"
 	default:
-		return a.goType
+		return a.CommonType
 	}
 }
 
@@ -61,8 +61,8 @@ func buildAttrs(args []string) []attr {
 		}
 
 		attrs = append(attrs, attr{
-			Name:   name.New(slice[0]),
-			goType: strings.ToLower(slice[1]),
+			Name:       name.New(slice[0]),
+			CommonType: strings.ToLower(slice[1]),
 		})
 	}
 

--- a/tools/buffalo/model/attributes_test.go
+++ b/tools/buffalo/model/attributes_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_BuildAttrs(t *testing.T) {
-	defaults := []attr{{Name: name.New("id"), goType: "uuid"}, {Name: name.New("created_at"), goType: "timestamp"}, {Name: name.New("updated_at"), goType: "timestamp"}}
+	defaults := []attr{{Name: name.New("id"), CommonType: "uuid"}, {Name: name.New("created_at"), CommonType: "timestamp"}, {Name: name.New("updated_at"), CommonType: "timestamp"}}
 
 	cases := []struct {
 		args     []string
@@ -23,17 +23,17 @@ func Test_BuildAttrs(t *testing.T) {
 		{
 			testName: "Some Args Without Type",
 			args:     []string{"description:text", "title"},
-			expected: []attr{{Name: name.New("id"), goType: "uuid"}, {Name: name.New("created_at"), goType: "timestamp"}, {Name: name.New("updated_at"), goType: "timestamp"}, {Name: name.New("description"), goType: "text"}, {Name: name.New("title"), goType: "string"}},
+			expected: []attr{{Name: name.New("id"), CommonType: "uuid"}, {Name: name.New("created_at"), CommonType: "timestamp"}, {Name: name.New("updated_at"), CommonType: "timestamp"}, {Name: name.New("description"), CommonType: "text"}, {Name: name.New("title"), CommonType: "string"}},
 		},
 		{
 			testName: "Replacing Defaults",
 			args:     []string{"description:text", "id:int"},
-			expected: []attr{{Name: name.New("created_at"), goType: "timestamp"}, {Name: name.New("updated_at"), goType: "timestamp"}, {Name: name.New("description"), goType: "text"}, {Name: name.New("id"), goType: "int"}},
+			expected: []attr{{Name: name.New("created_at"), CommonType: "timestamp"}, {Name: name.New("updated_at"), CommonType: "timestamp"}, {Name: name.New("description"), CommonType: "text"}, {Name: name.New("id"), CommonType: "int"}},
 		},
 		{
 			testName: "Replacing Defaults 2",
 			args:     []string{"created_at:int", "description:text", "updated_at:int", "id:int"},
-			expected: []attr{{Name: name.New("created_at"), goType: "int"}, {Name: name.New("description"), goType: "text"}, {Name: name.New("updated_at"), goType: "int"}, {Name: name.New("id"), goType: "int"}},
+			expected: []attr{{Name: name.New("created_at"), CommonType: "int"}, {Name: name.New("description"), CommonType: "text"}, {Name: name.New("updated_at"), CommonType: "int"}, {Name: name.New("id"), CommonType: "int"}},
 		},
 	}
 

--- a/tools/buffalo/model/generator.go
+++ b/tools/buffalo/model/generator.go
@@ -1,25 +1,22 @@
 package model
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"html/template"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/gobuffalo/flect"
-	"github.com/gobuffalo/flect/name"
 	"github.com/pkg/errors"
 )
 
+var (
+	ErrModelAlreadyExists error = errors.New("model already exists")
+	ErrModelDirNotFound   error = errors.New("models folder do not exists on your buffalo app, please ensure the folder exists in order to proceed")
+)
+
 // Generator allows to identify model as a plugin
-type Generator struct {
-	name     string
-	filename string
-	dir      string
-}
+type Generator struct{}
 
 // Name returns the name of the generator plugin
 func (g Generator) Name() string {
@@ -34,89 +31,22 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 
 	dirPath := filepath.Join(root, "app", "models")
 	if !g.exists(dirPath) {
-		return errors.Errorf("folder '%s' do not exists on your buffalo app, please ensure the folder exists in order to proceed", dirPath)
+		return ErrModelDirNotFound
 	}
 
-	g.name = flect.Singularize(args[2])
-	g.filename = flect.Singularize(flect.Underscore(args[2]))
-	g.dir = dirPath
+	name := flect.Singularize(args[2])
+	filename := flect.Singularize(flect.Underscore(args[2]))
 
-	if g.exists(filepath.Join(g.dir, g.filename+".go")) {
-		return errors.Errorf("model already exists")
+	if g.exists(filepath.Join(dirPath, filename+".go")) {
+		return ErrModelAlreadyExists
 	}
 
-	if err := g.generateModelFiles(args[3:]); err != nil {
-		return err
+	model := New(dirPath, args[2], args[3:])
+	if err := model.Create(); err != nil {
+		return errors.Wrap(err, "creating models error")
 	}
 
-	fmt.Printf("[info] Model generated in: \n-- app/models/%s.go\n-- app/models/%s_test.go\n", g.name, g.name)
-
-	return nil
-}
-
-func (g Generator) generateModelFiles(args []string) error {
-	if err := g.createModelFile(args); err != nil {
-		return errors.Wrap(err, "creating model file")
-	}
-
-	if err := g.createModelTestFile(); err != nil {
-		return errors.Wrap(err, "creating model test file")
-	}
-
-	return nil
-}
-
-func (g Generator) createModelFile(args []string) error {
-	filename := g.filename + ".go"
-	path := filepath.Join(g.dir, filename)
-	attrs := buildAttrs(args)
-	data := opts{
-		Original: g.name,
-		Name:     name.New(g.name),
-		Attrs:    attrs,
-		Imports:  buildImports(attrs),
-	}
-
-	tmpl, err := template.New(filename).Parse(modelTemplate)
-	if err != nil {
-		return errors.Wrap(err, "parsing new template error")
-	}
-
-	var tpl bytes.Buffer
-	if err := tmpl.Execute(&tpl, data); err != nil {
-		return errors.Wrap(err, "executing new template error")
-	}
-
-	err = ioutil.WriteFile(path, tpl.Bytes(), 0655)
-	if err != nil {
-		return errors.Wrap(err, "writing new template error")
-	}
-
-	return nil
-}
-
-func (g Generator) createModelTestFile() error {
-	filename := g.filename + "_test.go"
-	path := filepath.Join(g.dir, filename)
-	data := opts{
-		Original: g.name,
-		Name:     name.New(g.name),
-	}
-
-	tmpl, err := template.New(filename).Parse(modelTestTemplate)
-	if err != nil {
-		return errors.Wrap(err, "parsing new template error")
-	}
-
-	var tpl bytes.Buffer
-	if err := tmpl.Execute(&tpl, data); err != nil {
-		return errors.Wrap(err, "executing new template error")
-	}
-
-	err = ioutil.WriteFile(path, tpl.Bytes(), 0655)
-	if err != nil {
-		return errors.Wrap(err, "writing new template error")
-	}
+	fmt.Printf("[info] Model generated in: \n-- app/models/%s.go\n-- app/models/%s_test.go\n", name, name)
 
 	return nil
 }

--- a/tools/buffalo/model/imports_test.go
+++ b/tools/buffalo/model/imports_test.go
@@ -15,12 +15,12 @@ func Test_BuildImports(t *testing.T) {
 	}{
 		{
 			testName: "With Default Attributes",
-			attrs:    []attr{{Name: name.New("id"), goType: "uuid"}, {Name: name.New("created_at"), goType: "timestamp"}, {Name: name.New("updated_at"), goType: "timestamp"}},
+			attrs:    []attr{{Name: name.New("id"), CommonType: "uuid"}, {Name: name.New("created_at"), CommonType: "timestamp"}, {Name: name.New("updated_at"), CommonType: "timestamp"}},
 			expected: []string{"fmt", "github.com/gofrs/uuid", "time"},
 		},
 		{
 			testName: "All Possible Attributes",
-			attrs:    []attr{{Name: name.New("id"), goType: "uuid"}, {Name: name.New("created_at"), goType: "timestamp"}, {Name: name.New("updated_at"), goType: "timestamp"}, {Name: name.New("description"), goType: "nulls.String"}, {Name: name.New("prices"), goType: "slices.Float"}},
+			attrs:    []attr{{Name: name.New("id"), CommonType: "uuid"}, {Name: name.New("created_at"), CommonType: "timestamp"}, {Name: name.New("updated_at"), CommonType: "timestamp"}, {Name: name.New("description"), CommonType: "nulls.String"}, {Name: name.New("prices"), CommonType: "slices.Float"}},
 			expected: []string{"fmt", "github.com/gobuffalo/nulls", "github.com/gobuffalo/pop/v5/slices", "github.com/gofrs/uuid", "time"},
 		},
 	}

--- a/tools/buffalo/model/model.go
+++ b/tools/buffalo/model/model.go
@@ -1,18 +1,96 @@
 package model
 
 import (
-	"strings"
+	"bytes"
+	"html/template"
+	"io/ioutil"
+	"path/filepath"
 
+	"github.com/gobuffalo/flect"
 	"github.com/gobuffalo/flect/name"
+	"github.com/pkg/errors"
 )
 
-type opts struct {
-	Name     name.Ident
-	Original string
-	Attrs    []attr
-	Imports  []string
+type Model struct {
+	Attrs []attr
+
+	dir      string
+	name     string
+	filename string
 }
 
-func (o opts) Char() string {
-	return strings.ToLower(o.Original[:1])
+func New(dirPath, name string, args []string) Model {
+	return Model{
+		Attrs: buildAttrs(args),
+
+		dir:      dirPath,
+		filename: flect.Singularize(flect.Underscore(name)),
+		name:     flect.Singularize(name),
+	}
+}
+
+func (m Model) Create() error {
+	if err := m.createModelFile(); err != nil {
+		return err
+	}
+
+	if err := m.createModelTestFile(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m Model) createModelFile() error {
+	filename := m.filename + ".go"
+	path := filepath.Join(m.dir, filename)
+	data := opts{
+		Original: m.name,
+		Name:     name.New(m.name),
+		Attrs:    m.Attrs,
+		Imports:  buildImports(m.Attrs),
+	}
+
+	tmpl, err := template.New(filename).Parse(modelTemplate)
+	if err != nil {
+		return errors.Wrap(err, "parsing new template error")
+	}
+
+	var tpl bytes.Buffer
+	if err := tmpl.Execute(&tpl, data); err != nil {
+		return errors.Wrap(err, "executing new template error")
+	}
+
+	err = ioutil.WriteFile(path, tpl.Bytes(), 0655)
+	if err != nil {
+		return errors.Wrap(err, "writing new template error")
+	}
+
+	return nil
+}
+
+func (m Model) createModelTestFile() error {
+	filename := m.filename + "_test.go"
+	path := filepath.Join(m.dir, filename)
+	data := opts{
+		Original: m.name,
+		Name:     name.New(m.name),
+	}
+
+	tmpl, err := template.New(filename).Parse(modelTestTemplate)
+	if err != nil {
+		return errors.Wrap(err, "parsing new template error")
+	}
+
+	var tpl bytes.Buffer
+	if err := tmpl.Execute(&tpl, data); err != nil {
+		return errors.Wrap(err, "executing new template error")
+	}
+
+	err = ioutil.WriteFile(path, tpl.Bytes(), 0655)
+	if err != nil {
+		return errors.Wrap(err, "writing new template error")
+	}
+
+	return nil
 }

--- a/tools/buffalo/model/opts.go
+++ b/tools/buffalo/model/opts.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/gobuffalo/flect/name"
+)
+
+type opts struct {
+	Name     name.Ident
+	Original string
+	Attrs    []attr
+	Imports  []string
+}
+
+func (o opts) Char() string {
+	return strings.ToLower(o.Original[:1])
+}

--- a/tools/buffalo/resource/generator.go
+++ b/tools/buffalo/resource/generator.go
@@ -31,7 +31,7 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 		return errors.Errorf("no name specified, please use `ox generate resource [name]`")
 	}
 
-	resource := New(root, args)
+	resource := New(root, args[2:])
 
 	// Generating Templates
 	fmt.Printf("[info] Generating Actions...\n")

--- a/tools/buffalo/resource/generator.go
+++ b/tools/buffalo/resource/generator.go
@@ -34,6 +34,12 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 	resource := New(root, args)
 
 	// Generating Templates
+	fmt.Printf("[info] Generating Actions...\n")
+	if err := resource.GenerateActions(); err != nil {
+		return errors.Wrap(err, "generating actions error")
+	}
+
+	// Generating Templates
 	fmt.Printf("[info] Generating Templates...\n")
 	if err := resource.GenerateTemplates(); err != nil {
 		return errors.Wrap(err, "generating templates error")
@@ -50,6 +56,8 @@ func (g Generator) Generate(ctx context.Context, root string, args []string) err
 	if err := resource.GenerateMigrations(); err != nil {
 		return errors.Wrap(err, "generating migrations error")
 	}
+
+	fmt.Printf("[info] %s resource has been generated successfully \n", resource.originalName)
 
 	return nil
 }

--- a/tools/buffalo/resource/generator.go
+++ b/tools/buffalo/resource/generator.go
@@ -1,0 +1,59 @@
+package resource
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/wawandco/oxplugins/tools/buffalo/model"
+	"github.com/wawandco/oxplugins/tools/pop/migration/creator"
+)
+
+// Generator allows to identify resource as a plugin
+type Generator struct{}
+
+// Name returns the name of the generator plugin
+func (g Generator) Name() string {
+	return "resource"
+}
+
+// Generate generates the actions, model, templates and migration files from the given attrs
+// app/actions/[name].go
+// app/actions/[name]_test.go
+// app/models/[name].go
+// app/models/[name]_test.go
+// app/templates/[name]/index.plush.html
+// app/templates/[name]/new.plush.html
+// app/templates/[name]/edit.plush.html
+// app/templates/[name]/show.plush.html
+// migration/[name].up.fizz
+// migration/[name].down.fizz
+func (g Generator) Generate(ctx context.Context, root string, args []string) error {
+	if len(args) < 3 {
+		return errors.Errorf("no name specified, please use `ox generate resource [name]`")
+	}
+
+	name := args[2]
+	attrs := args[3:]
+
+	// Generating Model
+	modelsPath := filepath.Join(root, "app", "models")
+	model := model.New(modelsPath, name, attrs)
+	if err := model.Create(); err != nil {
+		return errors.Wrap(err, "error creating model")
+	}
+
+	// Generating Migration
+	migrationPath := filepath.Join(root, "migrations")
+	creator, err := creator.CreateMigrationFor("fizz")
+	if err != nil {
+		return errors.Wrap(err, "error looking for migration creator")
+	}
+
+	if err = creator.Create(migrationPath, args[2:]); err != nil {
+		return errors.Wrap(err, "failed creating migrations")
+	}
+
+	return nil
+}

--- a/tools/buffalo/resource/generator.go
+++ b/tools/buffalo/resource/generator.go
@@ -27,8 +27,8 @@ func (g Generator) Name() string {
 // app/templates/[name]/new.plush.html
 // app/templates/[name]/edit.plush.html
 // app/templates/[name]/show.plush.html
-// migration/[name].up.fizz
-// migration/[name].down.fizz
+// migrations/[name].up.fizz
+// migrations/[name].down.fizz
 func (g Generator) Generate(ctx context.Context, root string, args []string) error {
 	if len(args) < 3 {
 		return errors.Errorf("no name specified, please use `ox generate resource [name]`")

--- a/tools/buffalo/resource/generator_test.go
+++ b/tools/buffalo/resource/generator_test.go
@@ -1,0 +1,46 @@
+package resource
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_Generate(t *testing.T) {
+	g := Generator{}
+	dir := t.TempDir()
+
+	// Creating folders before hand
+	folders := []string{"app/actions", "app/models", "app/templates", "migrations"}
+	for _, f := range folders {
+		actionsPath := filepath.Join(dir, f)
+		if err := os.MkdirAll(actionsPath, os.ModePerm); err != nil {
+			t.Errorf("creating %s folder should not be error, but got %v", f, err)
+		}
+	}
+
+	if err := g.Generate(context.Background(), dir, []string{"generate", "resource", "animals", "age:int", "breed", "nationality"}); err != nil {
+		t.Errorf("should not be error, but got %v", err)
+	}
+
+	// Validating Files existence
+	files := []string{
+		"app/actions/animals.go",
+		"app/actions/animals_test.go",
+		"app/models/animal.go",
+		"app/models/animal_test.go",
+		"app/templates/animals/index.plush.html",
+		"app/templates/animals/new.plush.html",
+		"app/templates/animals/edit.plush.html",
+		"app/templates/animals/show.plush.html",
+		"app/templates/animals/form.plush.html",
+	}
+
+	for _, f := range files {
+		path := filepath.Join(dir, f)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("'%s' file does not exists on the path", path)
+		}
+	}
+}

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -30,7 +30,7 @@ type Resource struct {
 // New creates a new instance of Resource
 func New(root string, args []string) *Resource {
 	modelsPath := filepath.Join(root, "app", "models")
-	model := model.New(modelsPath, args[2], args[3:])
+	model := model.New(modelsPath, args[0], args[0:])
 	actions := []name.Ident{
 		name.New("list"),
 		name.New("show"),
@@ -43,13 +43,13 @@ func New(root string, args []string) *Resource {
 
 	return &Resource{
 		Actions:  actions,
-		Args:     args[3:],
+		Args:     args[1:],
 		Model:    model,
 		ModelPkg: root + "/app/models",
-		Name:     name.New(args[2]),
+		Name:     name.New(args[0]),
 
-		originalArgs: args[2:],
-		originalName: args[2],
+		originalArgs: args[0:],
+		originalName: args[0],
 		root:         root,
 	}
 }

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -56,7 +56,7 @@ func New(root string, args []string) *Resource {
 
 // GenerateActions generates the actions for the resource
 func (r *Resource) GenerateActions() error {
-	actionName := r.Name.Proper().Underscore().String()
+	actionName := r.Name.Proper().Pluralize().Underscore().String()
 	dirPath := filepath.Join(r.root, "app", "actions")
 	actions := map[string]string{
 		actionName:           actionTmpl,

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -29,8 +29,6 @@ type Resource struct {
 
 // New creates a new instance of Resource
 func New(root string, args []string) *Resource {
-	os.Getwd()
-
 	modelsPath := filepath.Join(root, "app", "models")
 	model := model.New(modelsPath, args[2], args[3:])
 	actions := []name.Ident{

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -1,0 +1,104 @@
+package resource
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"github.com/gobuffalo/flect/name"
+	"github.com/pkg/errors"
+
+	"github.com/wawandco/oxplugins/tools/buffalo/model"
+	"github.com/wawandco/oxplugins/tools/pop/migration/creator"
+)
+
+// Resource model struct
+type Resource struct {
+	Name  name.Ident
+	Model model.Model
+	Args  []string
+
+	originalArgs []string
+	originalName string
+	root         string
+}
+
+// New creates a new instance of Resource
+func New(root string, args []string) *Resource {
+	modelsPath := filepath.Join(root, "app", "models")
+	model := model.New(modelsPath, args[2], args[3:])
+
+	return &Resource{
+		Args:  args[3:],
+		Model: model,
+		Name:  name.New(args[2]),
+
+		originalArgs: args[2:],
+	}
+}
+
+// GenerateModel generates the model for the resource
+func (r *Resource) GenerateModel() error {
+	if err := r.Model.Create(); err != nil {
+		return errors.Wrap(err, "error creating model")
+	}
+
+	return nil
+}
+
+// GenerateModel generates the migrations for the resource
+func (r *Resource) GenerateMigrations() error {
+	migrationPath := filepath.Join(r.root, "migrations")
+	creator, err := creator.CreateMigrationFor("fizz")
+	if err != nil {
+		return errors.Wrap(err, "error looking for migration creator")
+	}
+
+	if err = creator.Create(migrationPath, r.originalArgs[2:]); err != nil {
+		return errors.Wrap(err, "failed creating migrations")
+	}
+
+	return nil
+}
+
+// GenerateModel generates the templates for the resource
+func (r *Resource) GenerateTemplates() error {
+	templates := map[string]string{
+		"index": templateIndexTmpl,
+		"new":   templateNewTmpl,
+		"edit":  templateEditTmpl,
+		"show":  templateShowTmpl,
+		"form":  templateFormTmpl,
+	}
+
+	dirPath := filepath.Join(r.root, "app", "templates", r.Name.Underscore().String())
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		err = os.Mkdir(dirPath, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	for name, content := range templates {
+		filename := name + ".plush.html"
+		path := filepath.Join(dirPath, filename)
+
+		tmpl, err := template.New(filename).Parse(content)
+		if err != nil {
+			return errors.Wrap(err, "parsing new template error")
+		}
+
+		var tpl bytes.Buffer
+		if err = tmpl.Execute(&tpl, r); err != nil {
+			return errors.Wrap(err, "executing new template error")
+		}
+
+		if err = ioutil.WriteFile(path, tpl.Bytes(), 0655); err != nil {
+			return errors.Wrap(err, "writing new template error")
+		}
+	}
+
+	return nil
+}

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -56,7 +56,7 @@ func (r *Resource) GenerateMigrations() error {
 		return errors.Wrap(err, "error looking for migration creator")
 	}
 
-	if err = creator.Create(migrationPath, r.originalArgs[2:]); err != nil {
+	if err = creator.Create(migrationPath, r.originalArgs); err != nil {
 		return errors.Wrap(err, "failed creating migrations")
 	}
 

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gobuffalo/flect/name"
 	"github.com/pkg/errors"
 
+	"github.com/wawandco/oxplugins/internal/info"
 	"github.com/wawandco/oxplugins/tools/buffalo/model"
 	"github.com/wawandco/oxplugins/tools/pop/migration/creator"
 )
@@ -29,6 +30,11 @@ type Resource struct {
 
 // New creates a new instance of Resource
 func New(root string, args []string) *Resource {
+	module, err := info.ModuleName()
+	if err != nil {
+		module = root + "/app/models"
+	}
+
 	modelsPath := filepath.Join(root, "app", "models")
 	model := model.New(modelsPath, args[0], args[0:])
 	actions := []name.Ident{
@@ -45,7 +51,7 @@ func New(root string, args []string) *Resource {
 		Actions:  actions,
 		Args:     args[1:],
 		Model:    model,
-		ModelPkg: root + "/app/models",
+		ModelPkg: module + "/app/models",
 		Name:     name.New(args[0]),
 
 		originalArgs: args[0:],

--- a/tools/buffalo/resource/resource.go
+++ b/tools/buffalo/resource/resource.go
@@ -45,7 +45,7 @@ func New(root string, args []string) *Resource {
 		Actions:  actions,
 		Args:     args[3:],
 		Model:    model,
-		ModelPkg: root + "app/models",
+		ModelPkg: root + "/app/models",
 		Name:     name.New(args[2]),
 
 		originalArgs: args[2:],

--- a/tools/buffalo/resource/resource_test.go
+++ b/tools/buffalo/resource/resource_test.go
@@ -138,23 +138,11 @@ func Test_GenerateTemplates(t *testing.T) {
 
 	// Validating Files existence
 	templateFolder := filepath.Join(dir, "app", "templates", "cars")
-	if _, err := os.Stat(filepath.Join(templateFolder, "index.plush.html")); os.IsNotExist(err) {
-		t.Error("'index.plush.html' file does not exists on the path")
-	}
+	templates := []string{"index", "new", "edit", "show", "form"}
 
-	if _, err := os.Stat(filepath.Join(templateFolder, "new.plush.html")); os.IsNotExist(err) {
-		t.Error("'new.plush.html' file does not exists on the path")
-	}
-
-	if _, err := os.Stat(filepath.Join(templateFolder, "edit.plush.html")); os.IsNotExist(err) {
-		t.Error("'edit.plush.html' file does not exists on the path")
-	}
-
-	if _, err := os.Stat(filepath.Join(templateFolder, "show.plush.html")); os.IsNotExist(err) {
-		t.Error("'show.plush.html' file does not exists on the path")
-	}
-
-	if _, err := os.Stat(filepath.Join(templateFolder, "form.plush.html")); os.IsNotExist(err) {
-		t.Error("'form.plush.html' file does not exists on the path")
+	for _, tmpl := range templates {
+		if _, err := os.Stat(filepath.Join(templateFolder, tmpl+".plush.html")); os.IsNotExist(err) {
+			t.Error("'index.plush.html' file does not exists on the path")
+		}
 	}
 }

--- a/tools/buffalo/resource/resource_test.go
+++ b/tools/buffalo/resource/resource_test.go
@@ -1,0 +1,160 @@
+package resource
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func Test_GenerateActions(t *testing.T) {
+	dir := t.TempDir()
+	args := []string{"companies"}
+
+	if err := os.MkdirAll(filepath.Join(dir, "app", "actions"), os.ModePerm); err != nil {
+		t.Errorf("creating actions directory should not error, but got %v", err)
+	}
+
+	resource := New(dir, args)
+	if err := resource.GenerateActions(); err != nil {
+		t.Errorf("should not be error, but got %v", err)
+	}
+
+	// Checking Action Files
+	if _, err := os.Stat(filepath.Join(dir, "app", "actions", "companies.go")); os.IsNotExist(err) {
+		t.Error("'companies.go' file does not exists on the path")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "app", "actions", "companies_test.go")); os.IsNotExist(err) {
+		t.Error("'companies_test.go' file does not exists on the path")
+	}
+
+	// Validating existence of the attributes
+	companyDir := filepath.Join(dir, "app", "actions", "companies.go")
+	data, err := ioutil.ReadFile(companyDir)
+	if err != nil {
+		t.Error("reading file error")
+	}
+
+	stringData := string(data)
+	shouldContain := []string{
+		"func (v CompaniesResource) List(c buffalo.Context) error {",
+		"func (v CompaniesResource) New(c buffalo.Context) error {",
+		"func (v CompaniesResource) Show(c buffalo.Context) error {",
+		"func (v CompaniesResource) Update(c buffalo.Context) error {",
+		"func (v CompaniesResource) Destroy(c buffalo.Context) error {",
+		"func (v CompaniesResource) Create(c buffalo.Context) error {",
+	}
+	for _, contain := range shouldContain {
+		if !strings.Contains(stringData, contain) {
+			t.Errorf("unexpected content, file should contain '%s'", contain)
+		}
+	}
+}
+
+func Test_GenerateMigrations(t *testing.T) {
+	dir := t.TempDir()
+	args := []string{"events"}
+
+	if err := os.MkdirAll(filepath.Join(dir, "migrations"), os.ModePerm); err != nil {
+		t.Errorf("creating actions directory should not error, but got %v", err)
+	}
+
+	resource := New(dir, args)
+	if err := resource.GenerateMigrations(); err != nil {
+		t.Errorf("should not be error, but got %v", err)
+	}
+
+	// Validating Files existence
+	match, err := filepath.Glob(filepath.Join(dir, "migrations", "*events.*.fizz"))
+	if err != nil {
+		t.Errorf("searching for files should not error, but got %v", err)
+	}
+
+	if len(match) == 0 {
+		t.Error("migration files does not exists on the path")
+	}
+
+	if !strings.HasSuffix(match[0], "_events.down.fizz") {
+		t.Error("'events.up.fizz' file does not exists on the path")
+	}
+
+	if !strings.HasSuffix(match[1], "_events.up.fizz") {
+		t.Error("'events.down.fizz' file does not exists on the path")
+	}
+}
+
+func Test_GenerateModels(t *testing.T) {
+	dir := t.TempDir()
+	args := []string{"users", "first_name", "last_name", "email"}
+	modelsPath := filepath.Join(dir, "app", "models")
+	if err := os.MkdirAll(modelsPath, os.ModePerm); err != nil {
+		t.Errorf("creating templates folder should not be error, but got %v", err)
+	}
+
+	resource := New(dir, args)
+	if err := resource.GenerateModel(); err != nil {
+		t.Errorf("should not be error, but got %v", err)
+	}
+
+	// Validating Files existence
+	if _, err := os.Stat(filepath.Join(dir, "app", "models", "user.go")); os.IsNotExist(err) {
+		t.Error("'users.go' file does not exists on the path")
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "app", "models", "user_test.go")); os.IsNotExist(err) {
+		t.Error("'users_test.go' file does not exists on the path")
+	}
+
+	// Validating existence of the attributes
+	userFilePath := filepath.Join(modelsPath, "user.go")
+	data, err := ioutil.ReadFile(userFilePath)
+	if err != nil {
+		t.Error("reading file error")
+	}
+
+	stringData := string(data)
+	shouldContain := []string{"ID", "CreatedAt", "UpdatedAt", "FirstName", "LastName", "Email", "time.Time", "string"}
+	for _, contain := range shouldContain {
+		if !strings.Contains(stringData, contain) {
+			t.Errorf("unexpected content, file should contain '%s'", contain)
+		}
+	}
+}
+
+func Test_GenerateTemplates(t *testing.T) {
+	dir := t.TempDir()
+	args := []string{"cars", "model", "brand"}
+	modelsPath := filepath.Join(dir, "app", "templates")
+	if err := os.MkdirAll(modelsPath, os.ModePerm); err != nil {
+		t.Errorf("creating templates folder should not be error, but got %v", err)
+	}
+
+	resource := New(dir, args)
+	if err := resource.GenerateTemplates(); err != nil {
+		t.Errorf("should not be error, but got %v", err)
+	}
+
+	// Validating Files existence
+	templateFolder := filepath.Join(dir, "app", "templates", "cars")
+	if _, err := os.Stat(filepath.Join(templateFolder, "index.plush.html")); os.IsNotExist(err) {
+		t.Error("'index.plush.html' file does not exists on the path")
+	}
+
+	if _, err := os.Stat(filepath.Join(templateFolder, "new.plush.html")); os.IsNotExist(err) {
+		t.Error("'new.plush.html' file does not exists on the path")
+	}
+
+	if _, err := os.Stat(filepath.Join(templateFolder, "edit.plush.html")); os.IsNotExist(err) {
+		t.Error("'edit.plush.html' file does not exists on the path")
+	}
+
+	if _, err := os.Stat(filepath.Join(templateFolder, "show.plush.html")); os.IsNotExist(err) {
+		t.Error("'show.plush.html' file does not exists on the path")
+	}
+
+	if _, err := os.Stat(filepath.Join(templateFolder, "form.plush.html")); os.IsNotExist(err) {
+		t.Error("'form.plush.html' file does not exists on the path")
+	}
+}

--- a/tools/buffalo/resource/templates.go
+++ b/tools/buffalo/resource/templates.go
@@ -1,5 +1,224 @@
 package resource
 
+var actionTmpl string = `package actions
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gobuffalo/buffalo"
+	"github.com/gobuffalo/buffalo/render"
+	"github.com/gobuffalo/pop/v5"
+
+	"{{ .ModelPkg }}"
+)
+
+// {{ .Name.Resource }}Resource is the resource for the {{.Name.Proper}} model
+type {{ .Name.Resource }}Resource struct{
+	buffalo.Resource
+}
+
+// List gets all {{.Name.Group }}. This function is mapped to the path
+// GET /{{ .Name.URL }}
+func (v {{ .Name.Resource }}Resource) List(c buffalo.Context) error {
+	// Get the DB connection from the context
+	tx, ok := c.Value("tx").(*pop.Connection)
+	if !ok {
+		return fmt.Errorf("no transaction found")
+	}
+
+	{{.Name.VarCasePlural}} := &models.{{ .Name.Group }}{}
+
+	// Paginate results. Params "page" and "per_page" control pagination.
+	// Default values are "page=1" and "per_page=20".
+	q := tx.PaginateFromParams(c.Params())
+
+	// Retrieve all {{ .Name.Group }} from the DB
+	if err := q.All({{ .Name.VarCasePlural }}); err != nil {
+		return err
+	}
+
+    // Add the paginator to the context so it can be used in the template.
+    c.Set("pagination", q.Paginator)
+    c.Set("{{ .Name.VarCasePlural }}", {{ .Name.VarCasePlural }})
+
+    return c.Render(http.StatusOK, r.HTML("/{{ .Name.File.Pluralize }}/index.plush.html"))
+}
+
+// Show gets the data for one {{.Name.Proper}}. This function is mapped to
+// the path GET /{{ .Name.URL }}/{{"{"}}{{ .Name.ParamID }}}
+func (v {{ .Name.Resource }}Resource) Show(c buffalo.Context) error {
+	// Get the DB connection from the context
+	tx, ok := c.Value("tx").(*pop.Connection)
+	if !ok {
+		return fmt.Errorf("no transaction found")
+	}
+
+	// Allocate an empty {{ .Name.Proper }}
+	{{ .Name.VarCaseSingle }} := &models.{{ .Name.Proper }}{}
+
+	// To find the {{ .Name.Proper }} the parameter {{ .Name.ParamID }} is used.
+	if err := tx.Find({{ .Name.VarCaseSingle }}, c.Param("{{ .Name.ParamID }}")); err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+
+    c.Set("{{ .Name.VarCaseSingle }}", {{ .Name.VarCaseSingle }})
+
+    return c.Render(http.StatusOK, r.HTML("/{{ .Name.File.Pluralize }}/show.plush.html"))
+}
+
+// New renders the form for creating a new {{ .Name.Proper }}.
+// This function is mapped to the path GET /{{ .Name.URL }}/new
+func (v {{ .Name.Resource }}Resource) New(c buffalo.Context) error {
+	c.Set("{{.Name.VarCaseSingle}}", &models.{{ .Name.Proper }}{})
+
+	return c.Render(http.StatusOK, r.HTML("/{{ .Name.File.Pluralize }}/new.plush.html"))
+}
+
+// Create adds a {{ .Name.Proper }} to the DB. This function is mapped to the
+// path POST /{{ .Name.URL }}
+func (v {{ .Name.Resource }}Resource) Create(c buffalo.Context) error {
+	// Allocate an empty {{.Name.Proper}}
+	{{ .Name.VarCaseSingle }} := &models.{{ .Name.Proper }}{}
+
+	// Bind {{ .Name.VarCaseSingle }} to the html form elements
+	if err := c.Bind({{ .Name.VarCaseSingle }}); err != nil {
+		return err
+	}
+
+	// Get the DB connection from the context
+	tx, ok := c.Value("tx").(*pop.Connection)
+	if !ok {
+		return fmt.Errorf("no transaction found")
+	}
+
+	// Validate the data from the html form
+	verrs, err := tx.ValidateAndCreate({{ .Name.VarCaseSingle }})
+	if err != nil {
+		return err
+	}
+
+	if verrs.HasAny() {
+		// Make the errors available inside the html template
+		c.Set("errors", verrs)
+
+		// Render again the new.html template that the user can
+		// correct the input.
+		c.Set("{{ .Name.VarCaseSingle }}", {{ .Name.VarCaseSingle }})
+
+		return c.Render(http.StatusUnprocessableEntity, r.HTML("/{{ .Name.File.Pluralize }}/new.plush.html"))
+	}
+
+    // If there are no errors set a success message
+    c.Flash().Add("success","{{ .Name.VarCaseSingle }}.created.success")
+
+    // and redirect to the show page
+    return c.Redirect(http.StatusSeeOther, "{{ .Name.VarCaseSingle }}Path()", render.Data{"{{ .Name.ParamID }}": {{ .Name.VarCaseSingle }}.ID})
+}
+
+// Edit renders a edit form for a {{ .Name.Proper }}. This function is
+// mapped to the path GET /{{ .Name.URL }}/{{"{"}}{{ .Name.ParamID }}}/edit
+func (v {{ .Name.Resource }}Resource) Edit(c buffalo.Context) error {
+	// Get the DB connection from the context
+	tx, ok := c.Value("tx").(*pop.Connection)
+	if !ok {
+		return fmt.Errorf("no transaction found")
+	}
+
+	// Allocate an empty {{ .Name.Proper }}
+	{{ .Name.VarCaseSingle }} := &models.{{ .Name.Proper }}{}
+
+	if err := tx.Find({{ .Name.VarCaseSingle }}, c.Param("{{ .Name.ParamID }}")); err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+
+	c.Set("{{.Name.VarCaseSingle}}", {{.Name.VarCaseSingle}})
+
+	return c.Render(http.StatusOK, r.HTML("/{{.Name.File.Pluralize}}/edit.plush.html"))
+}
+
+// Update changes a {{ .Name.Proper }} in the DB. This function is mapped to
+// the path PUT /{{ .Name.URL}}/{{"{"}}{{ .Name.ParamID }}}
+func (v {{ .Name.Resource }}Resource) Update(c buffalo.Context) error {
+	// Get the DB connection from the context
+	tx, ok := c.Value("tx").(*pop.Connection)
+	if !ok {
+		return fmt.Errorf("no transaction found")
+	}
+
+	// Allocate an empty {{ .Name.Proper }}
+	{{ .Name.VarCaseSingle }} := &models.{{ .Name.Proper }}{}
+
+	if err := tx.Find({{ .Name.VarCaseSingle }}, c.Param("{{ .Name.ParamID }}")); err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+
+	// Bind {{ .Name.Proper }} to the html form elements
+	if err := c.Bind({{ .Name.VarCaseSingle }}); err != nil {
+		return err
+	}
+
+	verrs, err := tx.ValidateAndUpdate({{ .Name.VarCaseSingle }})
+	if err != nil {
+		return err
+	}
+
+	if verrs.HasAny() {
+		// Make the errors available inside the html template
+		c.Set("errors", verrs)
+
+		// Render again the edit.html template that the user can
+		// correct the input.
+		c.Set("{{ .Name.VarCaseSingle }}", {{ .Name.VarCaseSingle }})
+
+		return c.Render(http.StatusUnprocessableEntity, r.HTML("/{{ .Name.File.Pluralize }}/edit.plush.html"))
+	}
+
+    // If there are no errors set a success message
+    c.Flash().Add("success", "{{ .Name.VarCaseSingle }}.updated.success")
+
+    // and redirect to the show page
+    return c.Redirect(http.StatusSeeOther, "{{ .Name.VarCaseSingle }}Path()", render.Data{"{{ .Name.ParamID }}": {{ .Name.VarCaseSingle }}.ID})
+}
+
+// Destroy deletes a {{ .Name.Proper }} from the DB. This function is mapped
+// to the path DELETE /{{ .Name.URL }}/{{"{"}}{{ .Name.ParamID }}}
+func (v {{ .Name.Resource }}Resource) Destroy(c buffalo.Context) error {
+	// Get the DB connection from the context
+	tx, ok := c.Value("tx").(*pop.Connection)
+	if !ok {
+		return fmt.Errorf("no transaction found")
+	}
+
+	// Allocate an empty {{ .Name.Proper }}
+	{{ .Name.VarCaseSingle }} := &models.{{ .Name.Proper }}{}
+
+	// To find the {{ .Name.Proper }} the parameter {{ .Name.ParamID }} is used.
+	if err := tx.Find({{ .Name.VarCaseSingle }}, c.Param("{{ .Name.ParamID }}")); err != nil {
+		return c.Error(http.StatusNotFound, err)
+	}
+
+	if err := tx.Destroy({{ .Name.VarCaseSingle }}); err != nil {
+		return err
+	}
+
+    // If there are no errors set a flash message
+    c.Flash().Add("success", "{{ .Name.VarCaseSingle }}.destroyed.success")
+
+    // Redirect to the index page
+    return c.Redirect(http.StatusSeeOther, "{{ .Name.VarCasePlural }}Path()")
+}
+`
+
+var actionTestTmpl string = `package actions
+
+{{ range $a := .Actions }}
+func (as *ActionSuite) Test_{{$.Name.Resource}}Resource_{{ $a.Pascalize }}() {
+  	as.Fail("Not Implemented!")
+}
+{{ end }}
+`
+
 // templateIndexTmpl is a variable for the [template_name]/index.plush.html
 var templateIndexTmpl string = `<div class="py-4 mb-2">
 	<h3 class="d-inline-block">{{ .Name.Group }}</h3>

--- a/tools/buffalo/resource/templates.go
+++ b/tools/buffalo/resource/templates.go
@@ -1,0 +1,100 @@
+package resource
+
+// templateIndexTmpl is a variable for the [template_name]/index.plush.html
+var templateIndexTmpl string = `<div class="py-4 mb-2">
+	<h3 class="d-inline-block">{{ .Name.Group }}</h3>
+	<div class="float-right">
+		<%= linkTo(new{{ .Name.Resource }}Path(), {class: "btn btn-primary"}) { %>
+		Create New {{ .Name.Proper }}
+		<% } %>
+	</div>
+</div>
+
+<table class="table table-hover table-bordered">
+	<thead class="thead-light">
+		{{ range $p := .Model.Attrs -}}
+		{{ if ne $p.CommonType "text" -}}
+		<th>{{ $p.Name.Pascalize }}</th>
+		{{ end }}
+		{{- end -}}
+		<th>&nbsp;</th>
+	</thead>
+	<tbody>
+		<%= for ({{ .Name.VarCaseSingle }}) in {{ .Name.VarCasePlural }} { %>
+		<tr>
+			{{ range $mp := .Model.Attrs -}}
+			{{- if ne $mp.CommonType "text" -}}
+			<td class="align-middle"><%= {{ $.Name.VarCaseSingle }}.{{ $mp.Name.Pascalize }} %></td>
+			{{ end }}
+			{{- end -}}
+			<td>
+				<div class="float-right">
+					<%= linkTo({{ .Name.VarCaseSingle }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), {class: "btn btn-info", body: "View"}) %>
+					<%= linkTo(edit{{ .Name.Proper }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), {class: "btn btn-warning", body: "Edit"}) %>
+					<%= linkTo({{ .Name.VarCaseSingle }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), {class: "btn btn-danger", "data-method": "DELETE", "data-confirm": "Are you sure?", body: "Destroy"}) %>
+				</div>
+			</td>
+		</tr>
+		<% } %>
+	</tbody>
+</table>
+
+<div class="text-center">
+	<%= paginator(pagination) %>
+</div>`
+
+// templateNewTmpl is a variable for the [template_name]/new.plush.html
+var templateNewTmpl string = `<div class="py-4 mb-2">
+  	<h3 class="d-inline-block">New {{ .Name.Proper }}</h3>
+</div>
+
+<%= formFor({{.Name.VarCaseSingle}}, {action: {{ .Name.VarCasePlural }}Path(), method: "POST"}) { %>
+	<%= partial("{{ .Name.Folder.Pluralize }}/form.html") %>
+	<%= linkTo({{ .Name.VarCasePlural }}Path(), {class: "btn btn-warning", "data-confirm": "Are you sure?", body: "Cancel"}) %>
+<% } %>`
+
+// templateEditTmpl is a variable for the [template_name]/edit.plush.html
+var templateEditTmpl string = `<div class="py-4 mb-2">
+<h3 class="d-inline-block">Edit {{.Name.Proper}}</h3>
+</div>
+
+<%= formFor({{.Name.VarCaseSingle}}, {action: {{ .Name.VarCaseSingle }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), method: "PUT"}) { %>
+	<%= partial("{{ .Name.Folder.Pluralize }}/form.html") %>
+<%= linkTo({{ .Name.VarCaseSingle }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), {class: "btn btn-warning", "data-confirm": "Are you sure?", body: "Cancel"}) %>
+<% } %>`
+
+// templateShowTmpl is a variable for the [template_name]/show.plush.html
+var templateShowTmpl string = `<div class="py-4 mb-2">
+	<h3 class="d-inline-block">{{ .Name.Proper }} Details</h3>
+	<div class="float-right">
+		<%= linkTo({{ .Name.VarCasePlural }}Path(), {class: "btn btn-info"}) { %>
+		Back to all {{ .Name.Group }}
+		<% } %>
+		<%= linkTo(edit{{ .Name.Proper }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), {class: "btn btn-warning", body: "Edit"}) %>
+		<%= linkTo({{ .Name.VarCaseSingle }}Path({ {{ .Name.ParamID }}: {{ .Name.VarCaseSingle }}.ID }), {class: "btn btn-danger", "data-method": "DELETE", "data-confirm": "Are you sure?", body: "Destroy"}) %>
+	</div>
+</div>
+
+<ul class="list-group mb-2 ">
+{{- range $p := .Model.Attrs }}
+	<li class="list-group-item pb-1">
+		<label class="small d-block">{{ $p.Name.Pascalize }}</label>
+		<p class="d-inline-block"><%= {{$.Name.VarCaseSingle}}.{{$p.Name.Pascalize}} %></p>
+	</li>
+{{- end }}
+</ul>`
+
+// templateFormTmpl is a variable for the [template_name]/form.plush.html
+var templateFormTmpl string = `{{ range $p := .Model.Attrs -}}
+{{ if eq $p.CommonType "text" -}}
+<%= f.TextAreaTag("{{$p.Name.Pascalize}}", {rows: 10}) %>
+{{ else -}}
+{{ if eq $p.CommonType "bool" -}}
+<%= f.CheckboxTag("{{$p.Name.Pascalize}}", {unchecked: false}) %>
+{{ else -}}
+<%= f.InputTag("{{$p.Name.Pascalize}}") %>
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+<button class="btn btn-success" role="submit">Save</button>`

--- a/tools/pop/migration/creator/fizz_creator.go
+++ b/tools/pop/migration/creator/fizz_creator.go
@@ -71,7 +71,7 @@ func (f *FizzCreator) createDownFile(dir, name string, table fizz.Table) error {
 
 	file, err := os.Create(path)
 	if err != nil {
-		return errors.Wrap(err, "error creating file")
+		return errors.Wrap(err, "error creating down file")
 	}
 
 	defer file.Close()
@@ -79,7 +79,7 @@ func (f *FizzCreator) createDownFile(dir, name string, table fizz.Table) error {
 	writer := bufio.NewWriter(file)
 	_, err = writer.WriteString(table.UnFizz())
 	if err != nil {
-		return errors.Wrap(err, "error writing file")
+		return errors.Wrap(err, "error writing down file")
 	}
 
 	writer.Flush()
@@ -93,7 +93,7 @@ func (f *FizzCreator) createUPFile(dir, name string, table fizz.Table) error {
 
 	file, err := os.Create(path)
 	if err != nil {
-		return errors.Wrap(err, "error creating file")
+		return errors.Wrap(err, "error creating up file")
 	}
 
 	defer file.Close()
@@ -101,7 +101,7 @@ func (f *FizzCreator) createUPFile(dir, name string, table fizz.Table) error {
 	writer := bufio.NewWriter(file)
 	_, err = writer.WriteString(table.Fizz())
 	if err != nil {
-		return errors.Wrap(err, "error writing file")
+		return errors.Wrap(err, "error writing up file")
 	}
 
 	writer.Flush()


### PR DESCRIPTION
This PR adds the resource plugin for oxpecker, by typing:
```
ox generate resource animals age:int breed
```
it will generate the following files:
- app/actions/[name].go
- app/actions/[name]_test.go
- app/models/[name].go
- app/models/[name]_test.go
- app/templates/[name]/index.plush.html
- app/templates/[name]/new.plush.html
- app/templates/[name]/edit.plush.html
- app/templates/[name]/show.plush.html
- app/templates/[name]/form.plush.html
- migrations/[name].up.fizz
- migrations/[name].down.fizz

I also had to change the approach that I did for the models generator package in order to be used outside the package, that change don't break any functionality